### PR TITLE
Add available teams to team view

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -10,7 +10,6 @@ import TeamLeaderboard from '../views/TeamLeaderboard.vue';
 import TeamCreation from '../views/TeamCreation.vue';
 import TeamView from '../views/TeamView.vue';
 import CurrentReservations from '../views/CurrentReservations.vue';
-import AvailableTeams from '../views/AvailableTeams.vue';
 
 Vue.use(VueRouter);
 
@@ -60,11 +59,6 @@ const routes = [
     path: '/leaderboard',
     name: 'leaderboard',
     component: Leaderboard,
-  },
-  {
-    path: '/available-teams',
-    name: 'AvailableTeams',
-    component: AvailableTeams,
   },
   {
     path: '/reserve/:editmode',

--- a/src/views/TeamView.vue
+++ b/src/views/TeamView.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
+    <div v-if="inTeam">
       <h1>
         {{ name }}
         <img v-if="permissionLevel == 2" src="../assets/edit-icon.svg" alt="edit">
@@ -35,14 +36,22 @@
           <p v-else class="member">{{ member.username }}</p>
         </div>
       </div>
+    </div>
+    <available-teams v-if="!inTeam"/>
   </div>
 </template>
 
 <script>
+import AvailableTeams from './AvailableTeams.vue';
+
 export default {
   name: 'TeamView',
+  components: {
+    AvailableTeams,
+  },
   data() {
     return {
+      inTeam: true,
       id: 100,
       name: 'My Awesome Team',
       bio: 'Amazing team, count so many trees, all day long, preference for Sundays.',


### PR DESCRIPTION
The available teams view and the team overview are now on the same page, toggled by a new variable inTeam. If a user does not yet have a team they will see the available teams page, if they do they will see their own team overview.