### PR TITLE
changed mapview styling and removed styling from the map itself

### DIFF
--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -187,10 +187,5 @@ export default {
 </script>
 
 <style lang='scss' scoped>
-div {
-    padding: 0;
-    margin: 0;
-    width: 98vw;
-    height: 85vh;
-}
+
 </style>

--- a/src/views/MapView.vue
+++ b/src/views/MapView.vue
@@ -24,6 +24,7 @@
     </div>
 
     <Map
+      class="map-container"
       v-bind:reservedFilter="this.reservedFilter"
       v-bind:pushStreet="this.pushStreet"
       v-bind:activeStreetFid="this.activeStreetFid"/>
@@ -169,11 +170,9 @@ export default {
 .header-bar {
   display: flex;
   justify-content: space-evenly;
-  width: 100%;
-  margin: auto;
+  width: auto;
   background-color: #9AC356;
-  padding: 5px;
-  margin: 10px;
+  margin-bottom: 5px;
 }
 
 .streets-container {
@@ -188,8 +187,19 @@ export default {
 
 @media only screen and (max-width: 700px) {
   .streets-container {
-    width: 100%;
+    width: auto;
     margin-left: 5px;
+  }
+}
+
+.map-container {
+    width: 95vw;
+    height: 50vh;
+}
+
+@media only screen and (max-width: 700px) {
+  .map-container {
+    width: 100%;
   }
 }
 </style>


### PR DESCRIPTION
the problem was because there was a bit of styling on the map itself that was conflicting with styling on the map container. The size of the header is relative atm because there there are 2 rows of selected blocks on the current reservation block page. 

mobile:
![mobile](https://user-images.githubusercontent.com/19194912/83573678-cbf9d980-a4e0-11ea-8e77-da059b4e141a.PNG)

desktop: 
![desktop](https://user-images.githubusercontent.com/19194912/83573693-d61bd800-a4e0-11ea-893d-140072a562f2.PNG)
