### PR TITLE
Add Download for Teams and Block CSV

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -17,6 +17,7 @@ export const finishBlocks = async blocks => AxiosInstance.post(`${BLOCKS_RESERVA
 export const releaseBlocks = async blocks => AxiosInstance.post(`${BLOCKS_RESERVATION}/release`, blocks);
 export const resetBlocks = async blocks => AxiosInstance.post(`${BLOCKS_RESERVATION}/reset`, blocks);
 export const getReservedBlocks = async () => AxiosInstance.get(`${BLOCKS_RESERVATION}/reserved`);
+export const getBlocksCSV = async () => AxiosInstance.get(`${BLOCKS_RESERVATION}/export`);
 
 const BLOCKS_LEADERBOARD = '/api/v1/blocks/leaderboard';
 export const getBlocksLeaderboard = async () => AxiosInstance.get(BLOCKS_LEADERBOARD);

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -9,6 +9,7 @@ export const transferOwnership = async (id, member) => AxiosInstance.post(`${TEA
 export const disbandTeam = async id => AxiosInstance.post(`${TEAM}/${id}/disband`);
 export const getTeam = async id => AxiosInstance.get(`${TEAM}/${id}`);
 export const getAllTeams = async () => AxiosInstance.get(`${TEAM}`);
+export const getTeamsCSV = async () => AxiosInstance.get(`${TEAM}/export`);
 
 const BLOCKS_RESERVATION = '/api/v1/protected/blocks';
 export const reserveBlocks = async blocks => AxiosInstance.post(`${BLOCKS_RESERVATION}/reserve`, blocks);

--- a/src/constants/userConstants.js
+++ b/src/constants/userConstants.js
@@ -1,0 +1,7 @@
+const STANDARD = 'STANDARD';
+const ADMIN = 'ADMIN';
+
+export default {
+  STANDARD,
+  ADMIN,
+};

--- a/src/constants/userConstants.js
+++ b/src/constants/userConstants.js
@@ -1,7 +1,0 @@
-const STANDARD = 'STANDARD';
-const ADMIN = 'ADMIN';
-
-export default {
-  STANDARD,
-  ADMIN,
-};

--- a/src/views/AvailableTeams.vue
+++ b/src/views/AvailableTeams.vue
@@ -29,7 +29,7 @@
         </p>
       </router-link>
       <b-button class="create" @click="createTeam">Create New Team</b-button>
-      <b-button v-if="userData.privilegeLevel === userConstants.ADMIN"
+      <b-button v-if="isAdmin"
                 class="create"
                 @click="downloadCSV">
           Download Teams CSV
@@ -42,7 +42,7 @@ import Vue from 'vue';
 import VueRouter from 'vue-router';
 import { mapState } from 'vuex';
 import { getTeamsCSV } from '../api/api';
-import userConstants from '../constants/userConstants';
+import privilegeLevelConstants from '../auth/constants';
 
 Vue.use(VueRouter);
 
@@ -50,14 +50,18 @@ export default {
   name: 'availableTeams',
   data() {
     return {
-      userConstants,
+      privilegeLevelConstants,
     };
   },
   computed: {
     ...mapState({
       teams: 'teams',
       userData: 'userData',
+      privilegeLevel: 'privilegeLevel',
     }),
+    isAdmin() {
+      return this.privilegeLevel === privilegeLevelConstants.ADMIN;
+    },
     myTeams() {
       return this.teams.filter(e => e.userTeamRole !== 'NONE');
     },
@@ -73,15 +77,8 @@ export default {
     /**
      * Downloads a CSV that contains all Team/User information.
      */
-    async downloadCSV() {
-      try {
-        const resp = await getTeamsCSV();
-        if (resp.status === 200) {
-          this.forceFileDownload(resp.data, 'Teams Export Data');
-        }
-      } catch (error) {
-        // Something went wrong
-      }
+    downloadCSV() {
+      getTeamsCSV().then(resp => this.forceFileDownload(resp.data, 'Teams Export Data'));
     },
     /**
      * Forces a download of the given data under the given file name.

--- a/src/views/AvailableTeams.vue
+++ b/src/views/AvailableTeams.vue
@@ -31,8 +31,13 @@
       <b-button class="create" @click="createTeam">Create New Team</b-button>
       <b-button v-if="isAdmin"
                 class="create"
-                @click="downloadCSV">
+                @click="downloadTeamsCSV">
           Download Teams CSV
+      </b-button>
+      <b-button v-if="isAdmin"
+                class="create"
+                @click="downloadBlocksCSV">
+          Download Blocks CSV
       </b-button>
   </div>
 </template>
@@ -41,7 +46,7 @@
 import Vue from 'vue';
 import VueRouter from 'vue-router';
 import { mapState } from 'vuex';
-import { getTeamsCSV } from '../api/api';
+import { getBlocksCSV, getTeamsCSV } from '../api/api';
 import privilegeLevelConstants from '../auth/constants';
 
 Vue.use(VueRouter);
@@ -75,9 +80,15 @@ export default {
       this.$router.push('/create');
     },
     /**
+   * Downloads a CSV that contains all Block/User information.
+   */
+    downloadBlocksCSV() {
+      getBlocksCSV().then(resp => this.forceFileDownload(resp.data, 'Blocks Export Data'));
+    },
+    /**
      * Downloads a CSV that contains all Team/User information.
      */
-    downloadCSV() {
+    downloadTeamsCSV() {
       getTeamsCSV().then(resp => this.forceFileDownload(resp.data, 'Teams Export Data'));
     },
     /**


### PR DESCRIPTION
Add admin-only button to the `available-teams` page that downloads a CSV of all Team/User data