### PR TITLE
Forgot password route is now reachable without being logged in

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -130,7 +130,7 @@ const router = new VueRouter({
 
 router.beforeEach((to, from, next) => {
   if (tokenService.getPrivilegeLevel() < 0) {
-    if (to.name === 'Login' || to.name === 'SignUp') next();
+    if (to.name === 'Login' || to.name === 'SignUp' || to.path === '/forgot-password-reset/*') next();
     else next({ name: 'Login' });
   } else next();
   if (tokenService.getPrivilegeLevel() !== privilegeConstants.ADMIN) {


### PR DESCRIPTION
Ticket: [https://trello.com/c/UmvfKDDm](https://trello.com/c/UmvfKDDm)
Couldn't reach the forgot password route on the local instance so did not test but in theory it should work.