### PR TITLE
Sentry to production

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,4 @@
 VUE_APP_API_DOMAIN = "http://localhost:8081"
 VUE_APP_ARCGIS_URL = "https://services7.arcgis.com/iIw2JoTaLFMnHLgW/ArcGIS/rest/services/sftt_development_layer/FeatureServer/0"
 VUE_APP_PRIVATE_STREETS_URL = "https://services7.arcgis.com/iIw2JoTaLFMnHLgW/ArcGIS/rest/services/SFFT_Private_Streets/FeatureServer/0"
+VUE_APP_SENTRY_DSN = ""

--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,4 @@
 VUE_APP_API_DOMAIN = "https://api.sfttbos.org"
 VUE_APP_ARCGIS_URL = "https://services7.arcgis.com/iIw2JoTaLFMnHLgW/ArcGIS/rest/services/scott_lussier_sfft_street_segments/FeatureServer/0"
 VUE_APP_PRIVATE_STREETS_URL = "https://services7.arcgis.com/iIw2JoTaLFMnHLgW/ArcGIS/rest/services/SFFT_Private_Streets/FeatureServer/0"
+VUE_APP_SENTRY_DSN = "https://521cd3a837e643f687d530e7ac249b4d@o433473.ingest.sentry.io/5388723"

--- a/src/main.js
+++ b/src/main.js
@@ -12,6 +12,7 @@ import store from './store';
 Sentry.init({
   dsn: 'https://521cd3a837e643f687d530e7ac249b4d@o433473.ingest.sentry.io/5388723',
   integrations: [new VueIntegration({ Vue, attachProps: true })],
+  environment: process.env.production,
 });
 
 // Install BootstrapVue

--- a/src/main.js
+++ b/src/main.js
@@ -10,9 +10,8 @@ import store from './store';
 
 
 Sentry.init({
-  dsn: 'https://521cd3a837e643f687d530e7ac249b4d@o433473.ingest.sentry.io/5388723',
+  dsn: process.env.VUE_APP_SENTRY_DSN,
   integrations: [new VueIntegration({ Vue, attachProps: true })],
-  environment: process.env.production,
 });
 
 // Install BootstrapVue


### PR DESCRIPTION
Sentry key is no longer fetched when launching sfft locally

with dsn: 

![with-dsn](https://user-images.githubusercontent.com/19194912/92260265-a4325d00-eea5-11ea-8730-f6e83f07b6df.PNG)

without dsn:

![blank-dsn](https://user-images.githubusercontent.com/19194912/92260273-a98fa780-eea5-11ea-9ba0-9fcb7abccf64.PNG)
