### PR TITLE
made fix to map title and popup action icons

### DIFF
--- a/src/constants/mapConstants.js
+++ b/src/constants/mapConstants.js
@@ -9,7 +9,7 @@ const ADD_TO_RESERVE = {
 const ADD_TO_RELEASE = {
   title: 'Release',
   id: 'release',
-  image: 'https://upload.wikimedia.org/wikipedia/commons/8/8f/Checkmark.svg',
+  image: 'https://upload.wikimedia.org/wikipedia/commons/e/ea/Red-subtract-icon-png-13.png',
 };
 
 // The action button to add a block to the complete list

--- a/src/views/MapContainerView.vue
+++ b/src/views/MapContainerView.vue
@@ -1,7 +1,9 @@
 <template>
   <div>
     <page-title :returnButton="true" v-if="showHeader" :subtitle="this.header.subTitle" title="">
-      <h3 id="hide-title-tt" class="caret-icon" @click="showHeader=false">Reserve New Block ^</h3>
+      <h3 id="hide-title-tt" class="caret-icon" @click="showHeader=false">
+        {{this.header.headerVal}} ^
+        </h3>
       <b-tooltip target="hide-title-tt" triggers="hover" placement="bottom">
         Hide Title
       </b-tooltip>


### PR DESCRIPTION
Purely cosmetic.

In creating map constants, the "-" image for releasing blocks was replaced with a checkmark, this brings back the original "-". Also between my changes and Zach's changes the different titles that appear above different maps were lost, this brings that back.