### PR TITLE
fix console error on admin completions and reservations pages

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -53,10 +53,10 @@ export default new Vuex.Store({
       state.reservedBlocks = blockData;
     },
     setReservedBlocksAdmin(state, blockData) {
-      state.allReservedBlocks = blockData;
+      state.allReservedBlocks = blockData.blocks;
     },
     setCompletedBlocksAdmin(state, blockData) {
-      state.allCompletedBlocks = blockData;
+      state.allCompletedBlocks = blockData.blocks;
     },
   },
   actions: {

--- a/src/views/CompletionsOverview.vue
+++ b/src/views/CompletionsOverview.vue
@@ -2,7 +2,7 @@
   <div>
     <h1>Completed Blocks</h1>
     <p
-    v-if="allCompletedBlocks.blocks.length == 0"
+    v-if="allCompletedBlocks.length == 0"
     class="basicText">No blocks have been completed</p>
     <div v-else class="reservation-table">
       <b-row id="header" class="text-left">
@@ -11,7 +11,7 @@
         <b-col cols="4">Completion Date</b-col>
         <b-col cols="2" align-self="center"></b-col>
       </b-row>
-      <b-row class="text-left" v-for="block in allCompletedBlocks.blocks" :key="block.fid">
+      <b-row class="text-left" v-for="block in allCompletedBlocks" :key="block.fid">
         <b-col class="ids" cols="2" align-self="center">{{ block.id }}</b-col>
         <b-col cols="4" align-self="center">{{ block.username }}</b-col>
         <b-col cols="4" align-self="center">{{ formatDate(block.dateUpdated) }}</b-col>
@@ -37,7 +37,7 @@
         </b-col>
       </b-row>
     </div>
-    <b-button v-if="allCompletedBlocks.blocks.length > 0"
+    <b-button v-if="allCompletedBlocks.length > 0"
               class="download"
               @click="downloadBlocksCSV">
       Download Blocks CSV

--- a/src/views/ReservationsOverview.vue
+++ b/src/views/ReservationsOverview.vue
@@ -2,7 +2,7 @@
   <div>
     <page-title :title="'All Reservations'" />
     <p
-    v-if="allReservedBlocks.blocks.length === 0"
+    v-if="allReservedBlocks.length === 0"
     class="basicText">There are currently no reservations</p>
     <div v-else class="reservation-table">
       <b-row id="header" class="text-left">
@@ -11,7 +11,7 @@
         <b-col cols="4">Reservation Date</b-col>
         <b-col cols="2" align-self="start"></b-col>
       </b-row>
-      <b-row class="text-left" v-for="block in allReservedBlocks.blocks" :key="block.id">
+      <b-row class="text-left" v-for="block in allReservedBlocks" :key="block.id">
         <b-col class="ids" cols="2" align-self="center">{{ block.id }}</b-col>
         <b-col cols="4" align-self="center">{{ block.username }}</b-col>
         <b-col cols="4" align-self="center">{{ formatDate(block.dateUpdated) }}</b-col>
@@ -41,7 +41,7 @@
         </b-col>
       </b-row>
     </div>
-    <b-button v-if="allReservedBlocks.blocks.length > 0"
+    <b-button v-if="allReservedBlocks.length > 0"
               class="download"
               @click="downloadBlocksCSV">
       Download Blocks CSV


### PR DESCRIPTION
changed the setters in the store to set allCompletedBlocks and allReservedBlocks to the actual block list to avoid console error from mismatched typing between api and store