### PR TITLE
paginated the completed blocks overview

### DIFF
--- a/src/views/CompletionsOverview.vue
+++ b/src/views/CompletionsOverview.vue
@@ -5,13 +5,23 @@
     v-if="allCompletedBlocks.length == 0"
     class="basicText">No blocks have been completed</p>
     <div v-else class="reservation-table">
+      <p class="greenText"> Total Completed Blocks: {{ totalRows }}</p>
+      <b-pagination
+        v-model="currentPage"
+        :total-rows="totalRows"
+        :per-page="perPage"
+        aria-controls="completedBlock"
+      >
+        <template v-slot:first-text><span class="greenText">First</span></template>
+        <template v-slot:last-text><span class="greenText">Last</span></template>
+      </b-pagination>
       <b-row id="header" class="text-left">
         <b-col class="ids" cols="2">ID</b-col>
         <b-col cols="4">User</b-col>
         <b-col cols="4">Completion Date</b-col>
         <b-col cols="2" align-self="center"></b-col>
       </b-row>
-      <b-row class="text-left" v-for="block in allCompletedBlocks" :key="block.fid">
+      <b-row class="text-left" id="completedBlock" v-for="block in displayBlocks" :key="block.fid">
         <b-col class="ids" cols="2" align-self="center">{{ block.id }}</b-col>
         <b-col cols="4" align-self="center">{{ block.username }}</b-col>
         <b-col cols="4" align-self="center">{{ formatDate(block.dateUpdated) }}</b-col>
@@ -42,7 +52,8 @@
               @click="downloadBlocksCSV">
       Download Blocks CSV
     </b-button>
-  </div>
+ </div>
+
 </template>
 
 <script>
@@ -105,6 +116,24 @@ export default {
     ...mapState({
       allCompletedBlocks: 'allCompletedBlocks',
     }),
+
+    totalRows() {
+      return this.allCompletedBlocks.length;
+    },
+
+    displayBlocks() {
+      return this.allCompletedBlocks.slice(
+        (this.currentPage - 1) * this.perPage, this.currentPage * this.perPage,
+      );
+    },
+
+  },
+
+  data() {
+    return {
+      currentPage: 1,
+      perPage: 15,
+    };
   },
 
   mounted() {
@@ -155,5 +184,9 @@ button.download, button.download:hover, button.download:focus {
   padding: 0.5rem;
   margin: 1rem 5vw 0 0;
   float: right;
+}
+.greenText {
+  color: #086302;
+  font-weight: bold;
 }
 </style>

--- a/src/views/ReservationsOverview.vue
+++ b/src/views/ReservationsOverview.vue
@@ -5,13 +5,23 @@
     v-if="allReservedBlocks.length === 0"
     class="basicText">There are currently no reservations</p>
     <div v-else class="reservation-table">
+    <p class="greenText"> Total Reserved Blocks: {{ totalRows }}</p>
+    <b-pagination
+        v-model="currentPage"
+        :total-rows="totalRows"
+        :per-page="perPage"
+        aria-controls="reservedBlock"
+      >
+        <template v-slot:first-text><span class="greenText">First</span></template>
+        <template v-slot:last-text><span class="greenText">Last</span></template>
+      </b-pagination>
       <b-row id="header" class="text-left">
         <b-col class="ids" cols="2">ID</b-col>
         <b-col cols="4">User</b-col>
         <b-col cols="4">Reservation Date</b-col>
         <b-col cols="2" align-self="start"></b-col>
       </b-row>
-      <b-row class="text-left" v-for="block in allReservedBlocks" :key="block.id">
+      <b-row class="text-left" id="reservedBlock" v-for="block in displayBlocks" :key="block.id">
         <b-col class="ids" cols="2" align-self="center">{{ block.id }}</b-col>
         <b-col cols="4" align-self="center">{{ block.username }}</b-col>
         <b-col cols="4" align-self="center">{{ formatDate(block.dateUpdated) }}</b-col>
@@ -120,6 +130,23 @@ export default {
     ...mapState({
       allReservedBlocks: 'allReservedBlocks',
     }),
+
+    totalRows() {
+      return this.allReservedBlocks.length;
+    },
+
+    displayBlocks() {
+      return this.allReservedBlocks.slice(
+        (this.currentPage - 1) * this.perPage, this.currentPage * this.perPage,
+      );
+    },
+  },
+
+  data() {
+    return {
+      currentPage: 1,
+      perPage: 15,
+    };
   },
 
   mounted() {
@@ -170,5 +197,9 @@ button.download, button.download:hover, button.download:focus {
   padding: 0.5rem;
   margin: 1rem 5vw 0 0;
   float: right;
+}
+.greenText {
+  color: #086302;
+  font-weight: bold;
 }
 </style>


### PR DESCRIPTION
Why: https://code4community-team.monday.com/boards/702429655/pulses/716639335

This PR: Used Bootstrap’s pagination component for current page input control. Defined computed properties to determine the number of completed blocks (added a line to display this information to the user, also determines total page number) and which blocks to display per page. Stated each page should contain 15 blocks. Created a class and associated style to make changes fit the existing theme better.

Screenshots 
<img width="1680" alt="Screen Shot 2020-10-02 at 15 54 04" src="https://user-images.githubusercontent.com/22990100/94964283-8c132500-04c7-11eb-9d88-b0896fe2d8d4.png">
<img width="1680" alt="Screen Shot 2020-10-02 at 15 54 10" src="https://user-images.githubusercontent.com/22990100/94964285-8cabbb80-04c7-11eb-9406-a3a12c8074a6.png">
<img width="1680" alt="Screen Shot 2020-10-02 at 15 55 09" src="https://user-images.githubusercontent.com/22990100/94964350-a9e08a00-04c7-11eb-84dd-35ed31f6d3da.png">

Verification Steps: Added completed blocks, loaded the completed-blocks-overview view, checked that each page contained the proper number of blocks and that all completed blocks were listed. Added more completed blocks and ensured that more page buttons/all data became available.