### PR TITLE
Fix for empty page

### DIFF
--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -11,6 +11,11 @@
       <img src="../assets/trophy.svg" alt="trophy">
     </router-link>
   </div>
+  <div v-else>
+    <h3>Looks like you have been logged out.
+      <a href="/login">Click here</a>
+      to log back in</h3>
+  </div>
 </template>
 
 <script>


### PR DESCRIPTION
Doesn't fix this issue, but allows users to easily go to the home page and sign in again.
![image](https://user-images.githubusercontent.com/44882599/96271256-a99dbf80-0f9a-11eb-8e57-1976b2930f3f.png)
